### PR TITLE
Recent Ansible is picky about quotes that are used

### DIFF
--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -3,22 +3,22 @@
 - name: update the apt package index
   apt:
     update_cache: yes
-  when: ansible_pkg_mgr == 'apt'
+  when: ansible_pkg_mgr == "apt"
 
 - name: update the yum package index
   yum:
-    name: '*'
+    name: "*"
     state: latest
-  when: ansible_pkg_mgr == 'yum'
+  when: ansible_pkg_mgr == "yum"
 
-- include_vars: '{{ item }}'
+- include_vars: "{{ item }}"
   with_first_found:
-    - '../vars/{{ ansible_os_family }}-{{ ansible_userspace_bits }}.yml'
-    - '../vars/{{ ansible_os_family }}.yml'
-    - '../vars/Debian.yml'
+    - "../vars/{{ ansible_os_family }}-{{ ansible_userspace_bits }}.yml"
+    - "../vars/{{ ansible_os_family }}.yml"
+    - "../vars/Debian.yml"
 
 - name: install packages
   package:
-    name: '{{ item }}'
+    name: "{{ item }}"
     state: present
   with_items: "{{steamcmd_packages}}"

--- a/tasks/requirements.yml
+++ b/tasks/requirements.yml
@@ -1,9 +1,9 @@
 - name: check if anonymous steam account has no password
   fail:
-    msg: anonymous steam user mustn't have a password
+    msg: "anonymous steam user mustn't have a password"
   when: steamcmd_steam.username == 'anonymous' and steamcmd_steam.password
 
 - name: check if the password is set for non anonymous steam account
   fail:
-    msg: you must set a password to use another steam account or rather use anonymous account
+    msg: "you must set a password to use another steam account or rather use anonymous account"
   when: steamcmd_steam.username != 'anonymous' and not steamcmd_steam.password

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -2,41 +2,41 @@
 
 - name: create directory for SteamCMD app
   file:
-    path: '{{ steamcmd_directory }}'
+    path: "{{ steamcmd_directory }}"
     state: directory
     recurse: yes
 
 - name: create legacy directory for older apps
   file:
-    path: '{{ steamcmd_user_home }}.steam/sdk32/'
+    path: "{{ steamcmd_user_home }}.steam/sdk32/"
     state: directory
     recurse: yes
 
 - name: download SteamCMD for Linux
   get_url:
     url: https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz
-    dest: '{{ steamcmd_directory }}steamcmd_linux.tar.gz'
+    dest: "{{ steamcmd_directory }}steamcmd_linux.tar.gz"
     force: yes
-    headers: 'User-Agent: lutangar/ansible-role-steamcmd'
+    headers: "User-Agent: lutangar/ansible-role-steamcmd"
     validate_certs: no
 
 - name: extract the contents to cmd directory
   unarchive:
-    src: '{{ steamcmd_directory }}steamcmd_linux.tar.gz'
-    dest: '{{ steamcmd_directory }}'
+    src: "{{ steamcmd_directory }}steamcmd_linux.tar.gz"
+    dest: "{{ steamcmd_directory }}"
     copy: no
 
 - name: attempt to log into steam
-  command: '{{ steamcmd_directory }}steamcmd.sh +login {{ steamcmd_steam.username }} {{ steamcmd_steam.password }} +quit'
-  async: '{{ steamcmd_login_timeout}}'
+  command: "{{ steamcmd_directory }}steamcmd.sh +login {{ steamcmd_steam.username }} {{ steamcmd_steam.password }} +quit"
+  async: "{{ steamcmd_login_timeout}}"
   poll: 5
   register: steam_login
   no_log: yes
-  when: steamcmd_steam.guard == '~'
+  when: steamcmd_steam.guard == "~"
 
 - name: attempt to log into steam w/guard code
-  command: '{{ steamcmd_directory }}steamcmd.sh +set_steam_guard_code {{steamcmd_steam.guard}} +login {{ steamcmd_steam.username }} {{ steamcmd_steam.password }} +quit'
-  async: '{{ steamcmd_login_timeout}}'
+  command: "{{ steamcmd_directory }}steamcmd.sh +set_steam_guard_code {{steamcmd_steam.guard}} +login {{ steamcmd_steam.username }} {{ steamcmd_steam.password }} +quit"
+  async: "{{ steamcmd_login_timeout}}"
   poll: 5
   register: steam_login
   no_log: yes
@@ -44,8 +44,8 @@
 
 - name: linking steamclient.so to the ~/.steam/sdk32/steamclient.so directory
   file:
-    src: '{{ steamcmd_directory }}linux32/steamclient.so'
-    dest: '{{ steamcmd_user_home }}.steam/sdk32/steamclient.so'
+    src: "{{ steamcmd_directory }}linux32/steamclient.so"
+    dest: "{{ steamcmd_user_home }}.steam/sdk32/steamclient.so"
     state: link
     creates: yes
   when: steam_login.stdout.find('unable to locate a running instance of Steam, or a local steamclient.dll') != -1

--- a/tasks/user.yml
+++ b/tasks/user.yml
@@ -2,15 +2,15 @@
 
 - name: add steamcmd group
   group:
-    name: '{{ steamcmd_user }}'
+    name: "{{ steamcmd_user }}"
     state: present
 
 - name: add steamcmd user
   user:
-    name: '{{ steamcmd_user }}'
-    comment: 'Steam CMD user'
-    group: '{{ steamcmd_user }}'
+    name: "{{ steamcmd_user }}"
+    comment: "Steam CMD user"
+    group: "{{ steamcmd_user }}"
     append: yes
     createhome: yes
     shell: /bin/bash
-    home: '{{ steamcmd_user_home }}'
+    home: "{{ steamcmd_user_home }}"


### PR DESCRIPTION
Specifically, it will not interpret variables within single quotes (`'`)... Switched just about everything to double quotes (`"`), which is more yaml-y.

Previously, it bailed on the following on ansible 2.4.2.0

```
failed: [REDACTED] (item=steamcmd_packages) => {"changed": false, "item": "steamcmd_packages", "msg": "No package matching 'steamcmd_packages' is available"}
```