### PR TITLE
user zypper for SUSE machines

### DIFF
--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -19,3 +19,10 @@
     state: present
     update_cache: yes
   when: ansible_pkg_mgr == "yum"
+
+- name: install packages if zypper
+  yum:
+    name: "{{ steamcmd_packages }}"
+    state: present
+    update_cache: yes
+  when: ansible_pkg_mgr == "zypper"


### PR DESCRIPTION
use zypper for OpenSUSE machines. Otherwise it does not install dependencies and steamcmd doesn't run